### PR TITLE
Adding support for prettier ^2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [3.0.0](https://github.com/meteorlxy/eslint-plugin-prettier-vue/compare/v2.0.2...v3.0.0) (2020-04-08)
+
+
+### Features
+
+* Updating the version of Prettier([7759e99](https://github.com/meteorlxy/eslint-plugin-prettier-vue/commit/7759e99))
+
+
+### BREAKING CHANGES
+
+* Prettier 2.0.0 changes the default options for configuration and introduces some new formatting rules that are not configurable.
+
+
 ## [2.0.2](https://github.com/meteorlxy/eslint-plugin-prettier-vue/compare/v2.0.1...v2.0.2) (2019-10-24)
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install --save-dev \
 
 ### ESLint Config
 
-__DO NOT__ use `eslint-plugin-prettier` together. This plugin is based on `eslint-plugin-prettier` so you do not need it.
+**DO NOT** use `eslint-plugin-prettier` together. This plugin is based on `eslint-plugin-prettier` so you do not need it.
 
 ```js
 // .eslintrc.js
@@ -118,6 +118,14 @@ module.exports = {
     ],
   },
 }
+```
+
+## Using Prettier 1.X
+
+Prettier 2.0.0 introduced some breaking changes. If your porject is using it you should install version `2.0.2` of this package.
+
+```sh
+npm install --save-dev eslint-plugin-prettier-vue@^2.0.2
 ```
 
 ## LICENSE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-prettier-vue",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "ESLint plugin for Prettier formatting, which is better for Vue SFC",
   "homepage": "https://github.com/meteorlxy/eslint-plugin-prettier-vue",
   "repository": "https://github.com/meteorlxy/eslint-plugin-prettier-vue.git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@vue/component-compiler-utils": "^3.0.0",
     "chalk": "^2.4.2",
-    "prettier": "^1.18.2",
+    "prettier": "^2.0.0",
     "prettier-linter-helpers": "^1.0.0",
     "vue-template-compiler": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,10 +2245,10 @@ prettier@1.16.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.3.tgz#8c62168453badef702f34b45b6ee899574a6a65d"
   integrity sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
+  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
As stated in #7, the latest version of prettier introduces some [breaking changes](https://prettier.io/blog/2020/03/21/2.0.0.html)

This packages also runs prettier to suggest changes in the file, however, this package was using a version of prettier prior to `2.0.0`. This created an inconsistency if the code was properly formated by `prettier ^2.0.0`

This PR updates that dependency and also updates the readme for people still using prettier 1.x