### PR TITLE
feat: support setup script

### DIFF
--- a/src/rules/prettier/utils/parse-vue.ts
+++ b/src/rules/prettier/utils/parse-vue.ts
@@ -94,14 +94,16 @@ export const parseVue = ({
   filepath: string;
   options: SFCBlocksOptions;
 }): PrettierVueSFCBlock[] => {
-  const SFCBlocksOptions = {
+  const blocksOptions: Required<
+    Pick<SFCBlocksOptions, 'template' | 'script' | 'style'>
+  > = {
     template: options.template !== false,
     script: options.script !== false,
-    scriptSetup: options.script !== false,
     style: options.style !== false,
   };
 
-  const SFCCustomBlocksOptions = options.customBlocks || {};
+  const customBlocksOptions: Required<SFCBlocksOptions>['customBlocks'] =
+    options.customBlocks || {};
 
   // Get SFC descriptor by parsing source code
   const {
@@ -112,21 +114,23 @@ export const parseVue = ({
     pad: false,
   });
 
+  console.log(scriptSetup);
+
   // Filter SFC blocks
   const SFCBlocks = [template, script, scriptSetup, ...styles]
     .filter(<T>(block: T): block is Exclude<T, null> => block !== null)
-    .filter(({ type }) => SFCBlocksOptions[type]);
+    .filter(({ type }) => blocksOptions[type]);
 
   // Filter SFC custom blocks
   const SFCCustomBlocks = customBlocks
     .filter(
       ({ type }) =>
-        Object.keys(SFCCustomBlocksOptions).includes(type) &&
-        SFCCustomBlocksOptions[type] !== false,
+        Object.keys(customBlocksOptions).includes(type) &&
+        customBlocksOptions[type] !== false,
     )
     .map((block) => {
       // Resolve language of the SFC custom block
-      const customBlockOptions = SFCCustomBlocksOptions[block.type];
+      const customBlockOptions = customBlocksOptions[block.type];
 
       if (typeof block.attrs.lang === 'string') {
         block.lang = block.attrs.lang;

--- a/src/rules/prettier/utils/parse-vue.ts
+++ b/src/rules/prettier/utils/parse-vue.ts
@@ -52,9 +52,10 @@ const processSFCBlock = ({
     // `<template>`, `<script>`, `<style>` blocks should be treated as `.vue` file
     // to make the `vueIndentScriptAndStyle` option of prettier works, so we need
     // to wrap them with their original tags
-    const tagName = type === 'scriptSetup' ? 'script setup' : type;
-    const startingTag = `<${tagName}${lang ? ` lang="${lang}"` : ''}>`;
-    const endingTag = `</${tagName}>\n`;
+    const startingTag = `<${type}${type === 'scriptSetup' ? ' setup' : ''}${
+      lang ? ` lang="${lang}"` : ''
+    }>`;
+    const endingTag = `</${type}>\n`;
 
     const source = `${startingTag}${content}${endingTag}`;
 

--- a/src/rules/prettier/utils/parse-vue.ts
+++ b/src/rules/prettier/utils/parse-vue.ts
@@ -48,12 +48,13 @@ const processSFCBlock = ({
   loc,
   type,
 }: SFCBlock): PrettierVueSFCBlock => {
-  if (['template', 'script', 'style'].includes(type)) {
+  if (['template', 'script', 'scriptSetup', 'style'].includes(type)) {
     // `<template>`, `<script>`, `<style>` blocks should be treated as `.vue` file
     // to make the `vueIndentScriptAndStyle` option of prettier works, so we need
     // to wrap them with their original tags
-    const startingTag = `<${type}${lang ? ` lang="${lang}"` : ''}>`;
-    const endingTag = `</${type}>\n`;
+    const tagName = type === 'scriptSetup' ? 'script setup' : type;
+    const startingTag = `<${tagName}${lang ? ` lang="${lang}"` : ''}>`;
+    const endingTag = `</${tagName}>\n`;
 
     const source = `${startingTag}${content}${endingTag}`;
 
@@ -95,6 +96,7 @@ export const parseVue = ({
   const SFCBlocksOptions = {
     template: options.template !== false,
     script: options.script !== false,
+    scriptSetup: options.script !== false,
     style: options.style !== false,
   };
 
@@ -102,7 +104,7 @@ export const parseVue = ({
 
   // Get SFC descriptor by parsing source code
   const {
-    descriptor: { template, script, styles, customBlocks },
+    descriptor: { template, script, scriptSetup, styles, customBlocks },
   } = parse(source, {
     filename: path.basename(filepath),
     // do not add pad
@@ -110,7 +112,7 @@ export const parseVue = ({
   });
 
   // Filter SFC blocks
-  const SFCBlocks = [template, script, ...styles]
+  const SFCBlocks = [template, script, scriptSetup, ...styles]
     .filter(<T>(block: T): block is Exclude<T, null> => block !== null)
     .filter(({ type }) => SFCBlocksOptions[type]);
 

--- a/src/rules/prettier/utils/parse-vue.ts
+++ b/src/rules/prettier/utils/parse-vue.ts
@@ -48,13 +48,11 @@ const processSFCBlock = ({
   loc,
   type,
 }: SFCBlock): PrettierVueSFCBlock => {
-  if (['template', 'script', 'scriptSetup', 'style'].includes(type)) {
+  if (['template', 'script', 'style'].includes(type)) {
     // `<template>`, `<script>`, `<style>` blocks should be treated as `.vue` file
     // to make the `vueIndentScriptAndStyle` option of prettier works, so we need
     // to wrap them with their original tags
-    const startingTag = `<${type}${type === 'scriptSetup' ? ' setup' : ''}${
-      lang ? ` lang="${lang}"` : ''
-    }>`;
+    const startingTag = `<${type}${lang ? ` lang="${lang}"` : ''}>`;
     const endingTag = `</${type}>\n`;
 
     const source = `${startingTag}${content}${endingTag}`;
@@ -113,8 +111,6 @@ export const parseVue = ({
     // do not add pad
     pad: false,
   });
-
-  console.log(scriptSetup);
 
   // Filter SFC blocks
   const SFCBlocks = [template, script, scriptSetup, ...styles]

--- a/test/setup-script.vue
+++ b/test/setup-script.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <input id="multiple" class="attributes" v-model="attrOrder">
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const attrOrder = 'v-model'
+const refVal = ref("foo")
+</script>


### PR DESCRIPTION
The <script setup> tag is parsed by compiler-sfc as a scriptSetup in the
returned descriptor.

=========

Reference: <script setup> is an [RFC](https://github.com/vuejs/vue-next/pull/2532) that is available in vue 3.1.0-beta now.